### PR TITLE
[ HotFix Scope ] : JS-0123 Local variable name shadows variable in outer scope #38

### DIFF
--- a/docs/star.js
+++ b/docs/star.js
@@ -79,7 +79,7 @@ const createGlowPoint = (position) => {
 const determinePointQuantity = (distance) =>
   Math.max(Math.floor(distance / config.maximumGlowPointSpacing), 1);
 
-const createGlow = (last, current) => {
+const createGlow = (current) => {
   const distance = calcDistance(last, current);
   const quantity = determinePointQuantity(distance);
 

--- a/docs/star.js
+++ b/docs/star.js
@@ -38,7 +38,7 @@ const calcDistance = (a, b) => {
   return Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2));
 };
 
-const calcElapsedTime = ( end) => end - start;
+const calcElapsedTime = (end) => end - start;
 
 const appendElement = (element) => document.body.appendChild(element);
 const removeElement = (element, delay) =>

--- a/docs/star.js
+++ b/docs/star.js
@@ -38,7 +38,7 @@ const calcDistance = (a, b) => {
   return Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2));
 };
 
-const calcElapsedTime = (start, end) => end - start;
+const calcElapsedTime = ( end) => end - start;
 
 const appendElement = (element) => document.body.appendChild(element);
 const removeElement = (element, delay) =>
@@ -79,7 +79,7 @@ const createGlowPoint = (position) => {
 const determinePointQuantity = (distance) =>
   Math.max(Math.floor(distance / config.maximumGlowPointSpacing), 1);
 
-const createGlow = (current) => {
+const createGlow = (last, current) => {
   const distance = calcDistance(last, current);
   const quantity = determinePointQuantity(distance);
 


### PR DESCRIPTION
## Description
Two variables can have the same name if they&#x27;re declared in different scopes. In the example below, the parameter `x` is said to &quot;shadow&quot; the variable `x` declared above it. The outer `x` can no longer be accessed inside the `sum` function.

## Occurrences
There are 2 occurrences of this issue in the repository.

See all occurrences on DeepSource &rarr; [app.deepsource.com/gh/DamianSwanAAJHS2/SillyLittleFiles/issue/JS-0123/occurrences/](https://app.deepsource.com/gh/DamianSwanAAJHS2/SillyLittleFiles/issue/JS-0123/occurrences/)

## Introduction 

Bug was introduced in PR #3

## Resolution
Resolves #38