### PR TITLE
[ Workflow Patch ] : Ignore Dependabot Branches

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,20 +2,17 @@ name: Deploy to Preview Channel
 
 on:
   pull_request:
-    # Optionally configure to run only for specific files. For example:
-    # paths:
-    # - "website/**"
+    branches: [ !dependabot/** ]  # Exclude Dependabot branches
 
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Add any build steps here. For example:
-      # - run: npm ci && npm run build
+      # Add your build steps here (e.g., npm ci && npm run build)
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           expires: 1d
           projectId: sillylittlefiles


### PR DESCRIPTION
Exclude Dependabot branches from deploying to a preview channel, as for some reason.. they error out.